### PR TITLE
Fix user ip: issue #1

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
 apiKey=<Your geo.ipify apikey>
 mapboxToken=<Your mapboxToken>
 PORT=
+ENVIRON=local || prod

--- a/app.js
+++ b/app.js
@@ -11,13 +11,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 app.use(express.static('dist'));
-app.use(bodyParser.urlencoded({extended:true}));
+app.use(bodyParser.urlencoded({ extended: true }));
 
 app.set('view engine', 'ejs');
 app.set('trust proxy', true);
 
 const apiKey = process.env.apiKey;
 const mapboxToken = process.env.mapboxToken;
+const environ = process.env.environ;
 const baseUrl = `http://geo.ipify.org/api/v2/country?apiKey=${apiKey}`;
 
 // geo.ipify api does not return lat and long alongside its response 
@@ -26,43 +27,35 @@ const baseUrl = `http://geo.ipify.org/api/v2/country?apiKey=${apiKey}`;
 app.get("/", async (req, res) => {
 
     const resp = await fetch(baseUrl);
-    let  data = await resp.json();
-    const ipAddress = data.ip;
-    console.log(`${ipAddress} from API`)
-    console.log(`${req.ip} from req`)
-    console.log(`${req.headers['x-forwarded-for']} from x-forwarded`)
-    console.log(`${req.connection.remoteAddress} from remote addr`)
+    let data = await resp.json();
+    const ipAddress = environ == "local" ? data.ip : req.ip
     const latLongUrl = `http://ip-api.com/json/${ipAddress}?fields=lat,lon`;
     const latLongResp = await fetch(latLongUrl);
     const latLongData = await latLongResp.json();
     data.mapboxToken = mapboxToken;
-    data = {...data, ...latLongData};
+    data = { ...data, ...latLongData };
     res.render("index.ejs", data);
 });
 
 app.post("/", async (req, res) => {
     const resp = await fetch(baseUrl + `&ipAddress=${req.body.ip_address}`);
-    if (resp.status === 200){
+    if (resp.status === 200) {
         let data = await resp.json();
         const ipAddress = data.ip;
         const latLongUrl = `http://ip-api.com/json/${ipAddress}?fields=lat,lon`;
         const latLongResp = await fetch(latLongUrl);
         const latLongData = await latLongResp.json();
         data.mapboxToken = mapboxToken;
-        data = {...data, ...latLongData};
+        data = { ...data, ...latLongData };
         res.render("index.ejs", data);
-    } else{
+    } else {
         res.redirect("/");
     }
-    
+
 })
-
-
-
-console.log(apiKey);
 
 const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
-    console.log("Server listening on Port 3000");
+    console.log(`Server listening on Port: ${PORT}`);
 });

--- a/app.js
+++ b/app.js
@@ -14,10 +14,11 @@ app.use(express.static('dist'));
 app.use(bodyParser.urlencoded({extended:true}));
 
 app.set('view engine', 'ejs');
+app.set('trust proxy', true);
 
 const apiKey = process.env.apiKey;
 const mapboxToken = process.env.mapboxToken;
-const baseUrl = `https://geo.ipify.org/api/v2/country?apiKey=${apiKey}`;
+const baseUrl = `http://geo.ipify.org/api/v2/country?apiKey=${apiKey}`;
 
 // geo.ipify api does not return lat and long alongside its response 
 // I used another api to get the lat and long https://ip-api.com/
@@ -27,6 +28,10 @@ app.get("/", async (req, res) => {
     const resp = await fetch(baseUrl);
     let  data = await resp.json();
     const ipAddress = data.ip;
+    console.log(`${ipAddress} from API`)
+    console.log(`${req.ip} from req`)
+    console.log(`${req.headers['x-forwarded-for']} from x-forwarded`)
+    console.log(`${req.connection.remoteAddress} from remote addr`)
     const latLongUrl = `http://ip-api.com/json/${ipAddress}?fields=lat,lon`;
     const latLongResp = await fetch(latLongUrl);
     const latLongData = await latLongResp.json();

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/BOVAGE/IP-address-Tracker/issues"
   },
   "homepage": "https://github.com/BOVAGE/IP-address-Tracker#readme",
+  "engines": {
+    "node": "16.8.0"
+  },
   "dependencies": {
     "body-parser": "^1.20.0",
     "dotenv": "^16.0.1",


### PR DESCRIPTION
fix #1 

Made use of `req.ip` to obtain user's IP address and set trust proxy to true since there is proxy between client and server when deployed to heroku.

I ran a check on the different ways to obtain user's IP address. Here is what it's looks like on heroku logs

![logs](https://user-images.githubusercontent.com/67077455/194129598-d8a3cb88-35a9-4639-b886-e25c2be8c728.JPG)

For more info on the different ways to obtain user's IP address, click [here](https://stackabuse.com/bytes/how-to-get-a-users-ip-address-in-express-js/)
